### PR TITLE
template内でのN+1を修正

### DIFF
--- a/webapp/go/app.go
+++ b/webapp/go/app.go
@@ -572,9 +572,9 @@ func ListEntries(w http.ResponseWriter, r *http.Request) {
 	owner := getUserFromAccount(w, account)
 	var query string
 	if permitted(w, r, owner.ID) {
-		query = `SELECT *, (SELECT COUNT(*) FROM comments WHERE entry_id = ?) AS c FROM entries WHERE user_id = ? ORDER BY created_at DESC LIMIT 20`
+		query = `SELECT *, (SELECT COUNT(*) FROM comments WHERE entry_id = entries.id) AS c FROM entries WHERE user_id = ? ORDER BY created_at DESC LIMIT 20`
 	} else {
-		query = `SELECT *, (SELECT COUNT(*) FROM comments WHERE entry_id = ?) AS c FROM entries WHERE user_id = ? AND private=0 ORDER BY created_at DESC LIMIT 20`
+		query = `SELECT *, (SELECT COUNT(*) FROM comments WHERE entry_id = entries.id) AS c FROM entries WHERE user_id = ? AND private=0 ORDER BY created_at DESC LIMIT 20`
 	}
 	rows, err := db.Query(query, owner.ID)
 	if err != sql.ErrNoRows {

--- a/webapp/go/app.go
+++ b/webapp/go/app.go
@@ -303,7 +303,7 @@ func render(w http.ResponseWriter, r *http.Request, status int, file string, dat
 			var body string
 			var createdAt time.Time
 			checkErr(row.Scan(&entryID, &userID, &private, &body, &createdAt))
-			return Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt}
+			return Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt, 0}
 		},
 	}
 	tpl := template.Must(template.New(file).Funcs(fmap).ParseFiles(getTemplatePath(file), getTemplatePath("header.html")))
@@ -354,7 +354,7 @@ func GetIndex(w http.ResponseWriter, r *http.Request) {
 		var body string
 		var createdAt time.Time
 		checkErr(rows.Scan(&id, &userID, &private, &body, &createdAt))
-		entries = append(entries, Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt})
+		entries = append(entries, Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt, 0})
 	}
 	rows.Close()
 
@@ -392,7 +392,7 @@ LIMIT 10`, user.ID)
 		if !include(fids, userID) {
 			continue
 		}
-		entriesOfFriends = append(entriesOfFriends, Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt})
+		entriesOfFriends = append(entriesOfFriends, Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt, 0})
 		if len(entriesOfFriends) >= 10 {
 			break
 		}
@@ -415,7 +415,7 @@ LIMIT 10`, user.ID)
 		var body string
 		var createdAt time.Time
 		checkErr(row.Scan(&id, &userID, &private, &body, &createdAt))
-		entry := Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt}
+		entry := Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt, 0}
 		if entry.Private {
 			if !permitted(w, r, entry.UserID) {
 				continue
@@ -523,7 +523,7 @@ func GetProfile(w http.ResponseWriter, r *http.Request) {
 		var body string
 		var createdAt time.Time
 		checkErr(rows.Scan(&id, &userID, &private, &body, &createdAt))
-		entry := Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt}
+		entry := Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt, 0}
 		entries = append(entries, entry)
 	}
 	rows.Close()
@@ -615,7 +615,7 @@ func GetEntry(w http.ResponseWriter, r *http.Request) {
 		checkErr(ErrContentNotFound)
 	}
 	checkErr(err)
-	entry := Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt}
+	entry := Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt, 0}
 	owner := getUser(w, entry.UserID)
 	if entry.Private {
 		if !permitted(w, r, owner.ID) {
@@ -681,7 +681,7 @@ func PostComment(w http.ResponseWriter, r *http.Request) {
 	}
 	checkErr(err)
 
-	entry := Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt}
+	entry := Entry{id, userID, private == 1, strings.SplitN(body, "\n", 2)[0], strings.SplitN(body, "\n", 2)[1], createdAt, 0}
 	owner := getUser(w, entry.UserID)
 	if entry.Private {
 		if !permitted(w, r, owner.ID) {

--- a/webapp/go/templates/entries.html
+++ b/webapp/go/templates/entries.html
@@ -34,7 +34,7 @@
         </div>
         {{ if .Private }}<div class="text-danger entry-private">範囲: 友だち限定公開</div>{{ end }}
         <div class="entry-created-at">更新日時: {{ .CreatedAt.Format "2006-01-02 15:04:05" }}</div>
-        <div class="entry-comments">コメント: {{ numComments .ID }}件</div>
+        <div class="entry-comments">コメント: {{ .NumComments }}件</div>
     </div>
     {{ end }}
 </div>


### PR DESCRIPTION
refs #7 

templateから `numComments` 関数が呼ばれててN+1が起きていたので直す

```
# Query 6: 0.19 QPS, 0.00x concurrency, ID 0x043FEFA227769B85 at byte 216311802
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2023-05-05T07:08:46 to 2023-06-03T01:39:31
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         31  476720
# Exec time      4     46s    31us    31ms    96us   138us   115us    80us
# Lock time     27     15s     8us     8ms    31us    44us    43us    27us
# Rows sent      0 465.55k       1       1       1       1       0       1
# Rows examine   0 488.35k       0      11    1.05    3.89    1.27    0.99
# Query size    28  26.37M      58      58      58      58       0      58
# String:
# Databases    isucon5q
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  ################
#   1ms  #
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isucon5q` LIKE 'comments'\G
#    SHOW CREATE TABLE `isucon5q`.`comments`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT COUNT(*) AS c FROM comments WHERE entry_id = 497935\G
```